### PR TITLE
Menü 6 güncellemesinden sonra kullanılmayan mimari binary'lerini de temizle

### DIFF
--- a/keenetic_zapret2_manager.sh
+++ b/keenetic_zapret2_manager.sh
@@ -4558,6 +4558,7 @@ update_zapret2() {
     fi
     printf '%s\n' "$latest" > /opt/zapret2/version 2>/dev/null
     rm -rf "$tmpdir"
+    cleanup_files_after_extracted
     print_status PASS "$(T TXT_ZAP_UPDATE_OK)"
     # Binary surum dogrulamasi
     local nfqws_bin="/opt/zapret2/nfq2/nfqws2"


### PR DESCRIPTION
İlk kurulumda cleanup_files_after_extracted çağrılıyor ve binaries/ altındaki kullanılmayan mimariler (windows, android, x86, freebsd vb.) siliniyor. Menü 6 ile yapılan Zapret2 güncellemesinde bu çağrı yok, dolayısıyla güncelleme bütün mimarileri tekrar diske yazıyor.

Dahili depolaması düşük modellerde sorun çıkarıyor. KN-3610'da /opt 46 MB ve zapret2-vX.tar.gz açıldığında yaklaşık 18 MB yer tutuyor (yalnızca windows cygwin1.dll dosyaları ~6 MB). Önceki güncellemeden kalan binary'ler dururken yeni güncelleme yer bulamıyor ve tar "Arşiv açılamadı" hatası veriyor; aslında disk dolu. v1.0.1'e geçerken tam olarak bunu yaşadım, gereksiz opkg paketlerini silip yer açtıktan sonra güncelleyebildim.

Önerdiğim değişiklik update_zapret2 içinde, kurulum tamamlandıktan sonra cleanup_files_after_extracted çağrısını eklemek. Yani ilk kurulumdaki davranışın aynısı.

Test ettiğim ortam: KN-3610 (mips), KeeneticOS 5.0.11, KZM2 v26.6.8, Zapret2 v1.0.1. Güncelleme sonrası yaklaşık 13 MB geri kazanıldı, native linux-mips binary korundu ve bypass sorunsuz çalışmaya devam etti.
